### PR TITLE
Use Nullable.Equals to avoid boxing

### DIFF
--- a/src/FluentAssertions.NodaTime/AnnualDateAssertions.cs
+++ b/src/FluentAssertions.NodaTime/AnnualDateAssertions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -48,7 +49,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && Subject.Equals(other)) || (!Subject.HasValue && !other.HasValue))
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:AnnualDate} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<AnnualDateAssertions>(this);
@@ -73,7 +74,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && !Subject.Equals(other)) || (!Subject.HasValue && other.HasValue))
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:AnnualDate} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<AnnualDateAssertions>(this);

--- a/src/FluentAssertions.NodaTime/DurationAssertions.cs
+++ b/src/FluentAssertions.NodaTime/DurationAssertions.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && Subject.Equals(other)) || (!Subject.HasValue && !other.HasValue))
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:Duration} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<DurationAssertions>(this);
@@ -94,7 +94,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && !Subject.Equals(other)) || (!Subject.HasValue && other.HasValue))
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:Duration} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<DurationAssertions>(this);

--- a/src/FluentAssertions.NodaTime/InstantAssertions.cs
+++ b/src/FluentAssertions.NodaTime/InstantAssertions.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && Subject.Equals(other)) || (!Subject.HasValue && !other.HasValue))
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:Instant} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<InstantAssertions>(this);
@@ -114,7 +114,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && !Subject.Equals(other)) || (!Subject.HasValue && other.HasValue))
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:Instant} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<InstantAssertions>(this);

--- a/src/FluentAssertions.NodaTime/LocalDateAssertions.cs
+++ b/src/FluentAssertions.NodaTime/LocalDateAssertions.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && Subject.Equals(other) || !Subject.HasValue && !other.HasValue)
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:LocalDate} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<LocalDateAssertions>(this);
@@ -114,7 +114,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && !Subject.Equals(other) || !Subject.HasValue && other.HasValue)
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:LocalDate} to be equal to {0}{reason}.", other);
 
             return new AndConstraint<LocalDateAssertions>(this);

--- a/src/FluentAssertions.NodaTime/LocalDateTimeAssertions.cs
+++ b/src/FluentAssertions.NodaTime/LocalDateTimeAssertions.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && Subject.Equals(other) || !Subject.HasValue && !other.HasValue)
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:LocalDateTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<LocalDateTimeAssertions>(this);
@@ -114,7 +114,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && !Subject.Equals(other) || !Subject.HasValue && other.HasValue)
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:LocalDateTime} to be equal to {0}{reason}.", other, Subject);
 
             return new AndConstraint<LocalDateTimeAssertions>(this);

--- a/src/FluentAssertions.NodaTime/LocalTimeAssertions.cs
+++ b/src/FluentAssertions.NodaTime/LocalTimeAssertions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -45,7 +46,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && Subject.Equals(other) || !Subject.HasValue && !other.HasValue)
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:LocalTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<LocalTimeAssertions>(this);
@@ -71,7 +72,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && !Subject.Equals(other) || !Subject.HasValue && other.HasValue)
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:LocalTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<LocalTimeAssertions>(this);

--- a/src/FluentAssertions.NodaTime/OffsetAssertions.cs
+++ b/src/FluentAssertions.NodaTime/OffsetAssertions.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && Subject.Equals(other)) || (!Subject.HasValue && !other.HasValue))
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:Offset} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetAssertions>(this);
@@ -94,7 +94,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition((Subject.HasValue && !Subject.Equals(other)) || (!Subject.HasValue && other.HasValue))
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:Offset} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetAssertions>(this);

--- a/src/FluentAssertions.NodaTime/OffsetDateAssertions.cs
+++ b/src/FluentAssertions.NodaTime/OffsetDateAssertions.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && Subject.Equals(other) || !Subject.HasValue && !other.HasValue)
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:OffsetDate} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetDateAssertions>(this);
@@ -73,7 +73,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && !Subject.Equals(other) || !Subject.HasValue && other.HasValue)
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:OffsetDate} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetDateAssertions>(this);

--- a/src/FluentAssertions.NodaTime/OffsetDateTimeAssertions.cs
+++ b/src/FluentAssertions.NodaTime/OffsetDateTimeAssertions.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && Subject.Equals(other) || !Subject.HasValue && !other.HasValue)
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:OffsetDateTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetDateTimeAssertions>(this);
@@ -73,7 +73,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && !Subject.Equals(other) || !Subject.HasValue && other.HasValue)
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:OffsetDateTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetDateTimeAssertions>(this);

--- a/src/FluentAssertions.NodaTime/OffsetTimeAssertions.cs
+++ b/src/FluentAssertions.NodaTime/OffsetTimeAssertions.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && Subject.Equals(other) || !Subject.HasValue && !other.HasValue)
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:OffsetTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetTimeAssertions>(this);
@@ -72,7 +72,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && !Subject.Equals(other) || !Subject.HasValue && other.HasValue)
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:OffsetTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<OffsetTimeAssertions>(this);

--- a/src/FluentAssertions.NodaTime/ZonedDateTimeAssertions.cs
+++ b/src/FluentAssertions.NodaTime/ZonedDateTimeAssertions.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && Subject.Equals(other) || !Subject.HasValue && !other.HasValue)
+                .ForCondition(Nullable.Equals(Subject, other))
                 .FailWith("Expected {context:ZonedDateTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<ZonedDateTimeAssertions>(this);
@@ -73,7 +73,7 @@ namespace FluentAssertions.NodaTime
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue && !Subject.Equals(other) || !Subject.HasValue && other.HasValue)
+                .ForCondition(!Nullable.Equals(Subject, other))
                 .FailWith("Did not expect {context:ZonedDateTime} to be equal to {0}{reason}, but found {1}.", other, Subject);
 
             return new AndConstraint<ZonedDateTimeAssertions>(this);


### PR DESCRIPTION
Just had a look at the source code (which looks really great by the way) and found an opportunity to simplify comparing nullable types.